### PR TITLE
Update to latest stdlib version

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,7 +7,7 @@ repository = { type = "github", user = "larzconwell", repo = "flash" }
 gleam = ">= 1.0.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.36"
+gleam_stdlib = ">= 0.51.0 and < 2.0.0"
 birl = "~> 1.5"
 gleam_json = ">= 1.0.0 and < 3.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,17 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.7.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "5C66647D62BCB11FE327E7A6024907C4A17954EF22865FE0940B54A852446D01" },
-  { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
+  { name = "gleam_json", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "093214EB186A88D301795A94F0A8128C2E24CF1423997ED31A6C6CC67FC3E1A1" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
+  { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
 ]
 
 [requirements]
 birl = { version = "~> 1.5" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
-gleam_stdlib = { version = "~> 0.36" }
+gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -14,5 +14,5 @@ packages = [
 [requirements]
 birl = { version = "~> 1.5" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
-gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.51.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/flash.gleam
+++ b/src/flash.gleam
@@ -1,14 +1,14 @@
-import gleam/option.{type Option, None, Some}
-import gleam/io
+import birl
 import gleam/bool
 import gleam/float
 import gleam/int
-import gleam/string
-import gleam/string_builder
-import gleam/list
-import gleam/order
+import gleam/io
 import gleam/json
-import birl
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/order
+import gleam/string
+import gleam/string_tree
 
 /// Default logger that omits debug level logs and outputs a text format.
 pub const default = Logger(InfoLevel, text_writer, None, "", [])
@@ -169,19 +169,19 @@ pub fn json_writer(level: Level, message: String, attrs: List(Attr)) -> Nil {
 /// last attribute with the key is chosen.
 pub fn text_writer(level: Level, message: String, attrs: List(Attr)) -> Nil {
   let now = birl.get_time_of_day(birl.now())
-  let message = string.pad_right(message, 45, " ")
+  let message = string.pad_end(message, 45, " ")
   let level =
     level_to_string(level)
     |> string.uppercase
-    |> string.pad_right(to: 5, with: " ")
+    |> string.pad_end(to: 5, with: " ")
 
   let time_builder =
-    string_builder.from_strings([
-      string.pad_left(int.to_string(now.hour), 2, "0"),
+    string_tree.from_strings([
+      string.pad_start(int.to_string(now.hour), 2, "0"),
       ":",
-      string.pad_left(int.to_string(now.minute), 2, "0"),
+      string.pad_start(int.to_string(now.minute), 2, "0"),
       ":",
-      string.pad_left(int.to_string(now.second), 2, "0"),
+      string.pad_start(int.to_string(now.second), 2, "0"),
     ])
 
   let attrs =
@@ -189,16 +189,16 @@ pub fn text_writer(level: Level, message: String, attrs: List(Attr)) -> Nil {
     |> prepare_attrs
     |> list.map(attr_to_text)
 
-  string_builder.join(
+  string_tree.join(
     [
       time_builder,
-      string_builder.from_string(level),
-      string_builder.from_string(message),
+      string_tree.from_string(level),
+      string_tree.from_string(message),
       ..attrs
     ],
     " ",
   )
-  |> string_builder.to_string
+  |> string_tree.to_string
   |> io.println
 }
 
@@ -275,7 +275,7 @@ fn attr_to_json_value(attr) {
 }
 
 fn attr_to_text(attr) {
-  let from_strings = string_builder.from_strings
+  let from_strings = string_tree.from_strings
 
   case attr {
     BoolAttr(key, value) -> from_strings([key, "=", bool.to_string(value)])
@@ -293,7 +293,7 @@ fn attr_to_text(attr) {
           StringAttr(_, value) -> StringAttr(key, value)
         })
       })
-      |> string_builder.join(with: " ")
+      |> string_tree.join(with: " ")
     IntAttr(key, value) -> from_strings([key, "=", int.to_string(value)])
     StringAttr(key, value) -> from_strings([key, "=", value])
   }


### PR DESCRIPTION
Hello, 

This fixes the wonderful `flash` package to work with the latest stdlib, some `string` methods have been renamed and `string_builder` package has been removed for `string_tree`. The `gleam_stdlib` version constraint has been updated to match [that of the `gleam_json` package](https://github.com/gleam-lang/json/blob/fdc7e573640b1b87af493d7e863dc829106d2772/gleam.toml#L15).

Thanks,
Martin